### PR TITLE
Test variable PSSenderInfo exist

### DIFF
--- a/PPoShTools/Public/Log/Write-Log.ps1
+++ b/PPoShTools/Public/Log/Write-Log.ps1
@@ -131,7 +131,7 @@ Function Write-Log {
         else {
             $currentHostname = [system.environment]::MachineName
             $currentUsername = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-            if (Test-Path variable:PSSenderInfo) {
+            if (Test-Path -Path Variable:PSSenderInfo) {
                 $remotingFlag = '[R] '
             } 
             else {

--- a/PPoShTools/Public/Log/Write-Log.ps1
+++ b/PPoShTools/Public/Log/Write-Log.ps1
@@ -131,7 +131,7 @@ Function Write-Log {
         else {
             $currentHostname = [system.environment]::MachineName
             $currentUsername = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-            if (Get-Variable -Name PSSenderInfo -ErrorAction SilentlyContinue) {
+            if (Test-Path variable:PSSenderInfo) {
                 $remotingFlag = '[R] '
             } 
             else {


### PR DESCRIPTION
change 'Get-Variable -Name PSSenderInfo -ErrorAction SilentlyContinue' to 'Test-Path variable:PSSenderInfo' because when Set-StrictMode -version set to latest $error contains many errors which should be silently skkiped